### PR TITLE
Change similarity metric to lin metric

### DIFF
--- a/functional_tests/megago-test.py
+++ b/functional_tests/megago-test.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 import getopt
 import sys
 import subprocess

--- a/functional_tests/testdata/example_input_compare_goa.csv
+++ b/functional_tests/testdata/example_input_compare_goa.csv
@@ -1,23 +1,23 @@
 ID,set1,set2,expected_biological_process,expected_cellular_component,expected_molecular_function
-one level higher 1,GO:0030170,GO:0070279,0.0,0.0,0.9891598232064736
-one level higher 2,GO:0019842,GO:0036094,0.0,0.0,0.33563057060309276
-one level higher 3,GO:0030170,GO:0043168,0.0,0.0,0.33877743862689497
-two levels higher 1,GO:0030170,GO:0043167,0.0,0.0,0.16645336402284938
-two levels higher 2,GO:0030170,GO:0036094,0.0,0.0,0.31049772969269235
-two levels higher 3,GO:0070279,GO:0036094,0.0,0.0,0.31052926560026284
+one level higher 1,GO:0030170,GO:0070279,0.0,0.0,0.9999351409996573
+one level higher 2,GO:0019842,GO:0036094,0.0,0.0,0.4692505687974348
+one level higher 3,GO:0030170,GO:0043168,0.0,0.0,0.45800877009981067
+two levels higher 1,GO:0030170,GO:0043167,0.0,0.0,0.3013410567868916
+two levels higher 2,GO:0030170,GO:0036094,0.0,0.0,0.4341119344605537
+two levels higher 3,GO:0070279,GO:0036094,0.0,0.0,0.4341560253267057
 four levels higher,GO:0030170,GO:0003674,0.0,0.0,0.0
 two unrelated bindings (MF vs BP) 1,GO:0050662,GO:0001844,nan,0.0,nan
 two unrelated bindings (MF vs CC),GO:1903876,GO:0097524,0.0,nan,nan
 two unrelated bindings (MF vs BP) 2,GO:1903876,GO:0048290,nan,0.0,nan
-same level bindings (unrel) 1,GO:0043168;GO:0050662,GO:0050662;GO:0070279,0.0,0.0,0.49587563277412244
-same level bindings (unrel) 2,GO:0048038;GO:0050662,GO:0043295;GO:0031419,0.0,0.0,0.3783582162438666
-same level bindings (unrel) 3,GO:0001913;GO:0042267,GO:0070942;GO:0090634,0.898250923654065,0.0,0.0
-two children of parent 1,GO:0005488,GO:0048037;GO:0036094,0.0,0.0,0.11295263352259766
-two children of parent 2,GO:0098581,GO:0032490;GO:0098543,0.9640132009918313,0.0,0.0
-two children of parent (BP),GO:0050789,GO:0030155;GO:0031341,0.3681307979823229,0.0,0.0
-two children of binding VS two other children of binding,GO:0048037;GO:0036094,GO:1901363;GO:0097159,0.0,0.0,0.09699230064168216
+same level bindings (unrel) 1,GO:0043168;GO:0050662,GO:0050662;GO:0070279,0.0,0.0,0.5705441397363766
+same level bindings (unrel) 2,GO:0048038;GO:0050662,GO:0043295;GO:0031419,0.0,0.0,0.4206081016597252
+same level bindings (unrel) 3,GO:0001913;GO:0042267,GO:0070942;GO:0090634,0.8985352063919589,0.0,0.0
+two children of parent 1,GO:0005488,GO:0048037;GO:0036094,0.0,0.0,0.380532303385894
+two children of parent 2,GO:0098581,GO:0032490;GO:0098543,0.9642063715145586,0.0,0.0
+two children of parent (BP),GO:0050789,GO:0030155;GO:0031341,0.4538634724390884,0.0,0.0
+two children of binding VS two other children of binding,GO:0048037;GO:0036094,GO:1901363;GO:0097159,0.0,0.0,0.3267626652236698
 two children of biological process VS two other children of biological process,GO:0001906;GO:0009758,GO:0019740;GO:0098743,0.0,0.0,0.0
 one report; other not (BP),GO:0051712,,nan,0.0,0.0
-report specific; vs specific + parents,GO:0097159,GO:0097159;GO:0005488;GO:0003674,0.0,0.0,0.3038198818835536
+report specific; vs specific + parents,GO:0097159,GO:0097159;GO:0005488;GO:0003674,0.0,0.0,0.6654328927440821
 one report; other not,GO:0030170,,0.0,0.0,nan
 unrelated (GTPase activity) vs binding (PPB) activity,GO:0030170,GO:0003924,0.0,0.0,0.0

--- a/megago/megago.py
+++ b/megago/megago.py
@@ -208,7 +208,7 @@ def run_comparison(go_list_1, go_list_2, go_dag=None):
             freq_dict,
             go_dag,
             highest_ic_anc,
-            similarity_method="rel"
+            similarity_method="lin"
         ) for i in range(len(GO_DOMAINS))
     )
 

--- a/megago/megago.py
+++ b/megago/megago.py
@@ -206,7 +206,7 @@ def run_comparison(go_list_1, go_list_2, go_dag=None):
             freq_dict,
             go_dag,
             highest_ic_anc,
-            similarity_method="lin"
+            similarity_method="rel"
         ) for i in range(len(GO_DOMAINS))
     )
 

--- a/megago/megago.py
+++ b/megago/megago.py
@@ -183,6 +183,8 @@ def run_comparison(go_list_1, go_list_2, go_dag=None):
         All GO-terms present in the first sample.
     go_list_2 : a list with GO-identifiers as strings
         All GO-terms present in the second sample.
+    go_dag : GODag object
+        GODag object from the goatools package
 
     Returns
     -------

--- a/megago/megago.py
+++ b/megago/megago.py
@@ -206,7 +206,7 @@ def run_comparison(go_list_1, go_list_2, go_dag=None):
             freq_dict,
             go_dag,
             highest_ic_anc,
-            similarity_method=rel_metric
+            similarity_method=lin_metric
         ) for i in range(len(GO_DOMAINS))
     )
 

--- a/megago/megago.py
+++ b/megago/megago.py
@@ -16,7 +16,7 @@ from goatools.obo_parser import GODag
 
 from .constants import GO_DAG_FILE_PATH
 from .precompute_highest_ic import get_highest_ic
-from .metrics import compute_bma_metric, lin_metric, rel_metric
+from .metrics import compute_bma_metric
 from .precompute_frequency_counts import get_frequency_counts
 
 
@@ -206,7 +206,7 @@ def run_comparison(go_list_1, go_list_2, go_dag=None):
             freq_dict,
             go_dag,
             highest_ic_anc,
-            similarity_method=lin_metric
+            similarity_method="lin"
         ) for i in range(len(GO_DOMAINS))
     )
 

--- a/megago/megago.py
+++ b/megago/megago.py
@@ -16,7 +16,7 @@ from goatools.obo_parser import GODag
 
 from .constants import GO_DAG_FILE_PATH
 from .precompute_highest_ic import get_highest_ic
-from .metrics import compute_bma_metric
+from .metrics import compute_bma_metric, lin_metric, rel_metric
 from .precompute_frequency_counts import get_frequency_counts
 
 
@@ -205,7 +205,8 @@ def run_comparison(go_list_1, go_list_2, go_dag=None):
             split_per_domain_2[i],
             freq_dict,
             go_dag,
-            highest_ic_anc
+            highest_ic_anc,
+            similarity_method=rel_metric
         ) for i in range(len(GO_DOMAINS))
     )
 

--- a/megago/metrics.py
+++ b/megago/metrics.py
@@ -246,7 +246,7 @@ def _do_compute_max_sim_value(go_list1, go_list2, go_dag, term_counts, highest_i
 #
 
 
-def compute_bma_metric(go_list1, go_list2, term_counts, go_dag, highest_ic_anc, similarity_method=rel_metric):
+def compute_bma_metric(go_list1, go_list2, term_counts, go_dag, highest_ic_anc, similarity_method="rel"):
     """calculate the best match average similarity of the two provided sets of go terms
 
     For each GO term in go_list1, the similarity value of the most similar term from go_list2 is picked. The sum of
@@ -266,10 +266,8 @@ def compute_bma_metric(go_list1, go_list2, term_counts, go_dag, highest_ic_anc, 
         GODag object from the goatools package
     highest_ic_anc : dict
         dictionary: key: GO terms, values: information content of the ancestor with the highest information content
-    similarity_method : function
-        function with the following arguments: id1, id2, go_dag, term_counts, highest_ic_anc
-        must return a float or the value of the global variable NAN_VALUE.
-
+    similarity_method : string
+        choose between lin and rel metric. 'lin' -> lin_metric, 'rel' -> rel_metric
 
     Returns
     -------
@@ -277,17 +275,26 @@ def compute_bma_metric(go_list1, go_list2, term_counts, go_dag, highest_ic_anc, 
 
     """
 
+    sim_func = None
+    if similarity_method == "lin":
+        sim_func = lin_metric
+    elif similarity_method == "rel":
+        sim_func = rel_metric
+    else:
+        raise AttributeError(f"similarity_method must be in ['lin', 'rel'] but is {similarity_method}")
+
     summation_set12 = 0.0
     summation_set21 = 0.0
+
     for id1 in go_list1:
         similarity_values = []
         for id2 in go_list2:
-            similarity_values.append(similarity_method(id1, id2, go_dag, term_counts, highest_ic_anc))
+            similarity_values.append(sim_func(id1, id2, go_dag, term_counts, highest_ic_anc))
         summation_set12 += max(similarity_values + [NAN_VALUE])
     for id2 in go_list2:
         similarity_values = []
         for id1 in go_list1:
-            similarity_values.append(similarity_method(id2, id1, go_dag, term_counts, highest_ic_anc))
+            similarity_values.append(sim_func(id2, id1, go_dag, term_counts, highest_ic_anc))
         summation_set21 += max(similarity_values + [NAN_VALUE])
     if (len(go_list1) + len(go_list2)) == 0:
         bma = 0

--- a/megago/metrics.py
+++ b/megago/metrics.py
@@ -172,9 +172,9 @@ def lin_metric(c1, c2, go_dag, term_counts, highest_ic_anc):
 
     Formula of the metric: (2 * info_content(mica)) / (info_content(go_id1) + info_content(go_id2))
     where mica is the most informative common ancestor of go_id1 and go_id2.
-    Metric is implemented according to: Schlicker, A., Domingues, F.S., Rahnenführer, J. et al. A new measure for
-    functional similarity of gene products based on Gene Ontology. BMC Bioinformatics 7, 302 (2006)
-    doi:10.1186/1471-2105-7-302
+
+    Metric is implemented according to: Lin, Dekang. 1998. “An Information-Theoretic Definition of Similarity.” In
+    Proceedings of the 15th International Conference on Machine Learning, 296—304.
 
 
     Parameters


### PR DESCRIPTION
Add the lin metric for semantic similarity and make it the default.

formula: (2 * info_content(mica)) / (info_content(go_id1) + info_content(go_id2)) where mica is the most informative common ancestor of go_id1 and go_id2.

The lin metric is implemented according to: Lin, Dekang. 1998. “An Information-Theoretic Definition of Similarity.” In Proceedings of the 15th International Conference on Machine Learning, 296—304.

Fixes issue #32 